### PR TITLE
link 'O que há de novo no Python 3.0' quebrado

### DIFF
--- a/abop-ptbr.html
+++ b/abop-ptbr.html
@@ -641,7 +641,7 @@
       (recursos significativamente diferentes das versões anteriores de Python
       2.x e que provavelmente serão incluídos no Python 3.0)</li>
 
-      <li><a href="http://docs.python.org/dev/3.0/whatsnew/3.0.html" class=
+      <li><a href="http://docs.python.org/3.0/whatsnew/3.0.html" class=
       "external text" rel="nofollow">O que há de novo no Python 3.0</a></li>
 
       <li><a href="http://www.python.org/dev/peps/pep-0361/" class=


### PR DESCRIPTION
link 'O que há de novo no Python 3.0' estava quebrado